### PR TITLE
Updated PIA Port Forwarding API to use working API

### DIFF
--- a/deluge-pia-port-forwarding.sh
+++ b/deluge-pia-port-forwarding.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 # Source: http://www.htpcguides.com
 # Adapted from https://github.com/blindpet/piavpn-portforward/
-# Author: Mike
+# Author: Mike and George
 # Based on https://github.com/crapos/piavpn-portforward
 
 # Set path for root Cron Job
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
-USERNAME=piauser
-PASSWORD=piapass
 VPNINTERFACE=tun0
-VPNLOCALIP=$(ifconfig $VPNINTERFACE | awk '/inet / {print $2}' | awk 'BEGIN { FS = ":" } {print $(NF)}')
 CURL_TIMEOUT=5
-CLIENT_ID=$(uname -v | sha1sum | awk '{ print $1 }')
+CLIENT_ID=$(head -n 100 /dev/urandom | sha256sum | tr -d " -")
 
 # set to 1 if using VPN Split Tunnel
 SPLITVPN=""
@@ -26,7 +23,7 @@ VPNIP=$(curl -m $CURL_TIMEOUT --interface $VPNINTERFACE "http://ipinfo.io/ip" --
 echo $VPNIP
 
 #request new port
-PORTFORWARDJSON=$(curl -m $CURL_TIMEOUT --silent --interface $VPNINTERFACE  'https://www.privateinternetaccess.com/vpninfo/port_forward_assignment' -d "user=$USERNAME&pass=$PASSWORD&client_id=$CLIENT_ID&local_ip=$VPNLOCALIP" | head -1)
+PORTFORWARDJSON=$(curl --interface $VPNINTERFACE "http://209.222.18.222:2000/?client_id=$CLIENT_ID" 2>/dev/null)
 #trim VPN forwarded port from JSON
 PORT=$(echo $PORTFORWARDJSON | awk 'BEGIN{r=1;FS="{|:|}"} /port/{r=0; print $3} END{exit r}')
 echo $PORT  
@@ -43,6 +40,9 @@ if [ "$SPLITVPN" -eq "1" ]; then
     fi
 fi
 
-#change deluge port on the fly
+#print VPNIP and PORT to text file for easy viewing
+echo $VPNIP > /etc/openvpn/status.txt
+echo $PORT >> /etc/openvpn/status.txt
 
+#change deluge port on the fly
 deluge-console "connect $DELUGEHOST:58846 $DELUGEUSER $DELUGEPASS; config --set listen_ports ($PORT,$PORT)"

--- a/transmission-pia-port-forwarding.sh
+++ b/transmission-pia-port-forwarding.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 # Source: http://www.htpcguides.com
 # Adapted from https://github.com/blindpet/piavpn-portforward/
-# Author: Mike and Drake
+# Author: Mike, Drake and George
 # Based on https://github.com/crapos/piavpn-portforward
 
 # Set path for root Cron Job
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
-USERNAME=piauser
-PASSWORD=piapass
 VPNINTERFACE=tun0
-VPNLOCALIP=$(ifconfig $VPNINTERFACE | awk '/inet / {print $2}' | awk 'BEGIN { FS = ":" } {print $(NF)}')
 CURL_TIMEOUT=5
-CLIENT_ID=$(uname -v | sha1sum | awk '{ print $1 }')
+CLIENT_ID=$(head -n 100 /dev/urandom | sha256sum | tr -d " -")
 
 # set to 1 if using VPN Split Tunnel
 SPLITVPN=""
@@ -26,7 +23,7 @@ VPNIP=$(curl -m $CURL_TIMEOUT --interface $VPNINTERFACE "http://ipinfo.io/ip" --
 #echo $VPNIP
 
 #request new port
-PORTFORWARDJSON=$(curl -m $CURL_TIMEOUT --silent --interface $VPNINTERFACE  'https://www.privateinternetaccess.com/vpninfo/port_forward_assignment' -d "user=$USERNAME&pass=$PASSWORD&client_id=$CLIENT_ID&local_ip=$VPNLOCALIP" | head -1)
+PORTFORWARDJSON=$(curl --interface $VPNINTERFACE "http://209.222.18.222:2000/?client_id=$CLIENT_ID" 2>/dev/null)
 #trim VPN forwarded port from JSON
 PORT=$(echo $PORTFORWARDJSON | awk 'BEGIN{r=1;FS="{|:|}"} /port/{r=0; print $3} END{exit r}')
 #echo $PORT  
@@ -42,6 +39,10 @@ if [ "$SPLITVPN" -eq "1" ]; then
         sudo iptables -I INPUT 2 -i $VPNINTERFACE -p tcp --dport $PORT -j ACCEPT
     fi
 fi
+
+#print VPNIP and PORT to text file for easy viewing
+echo $VPNIP > /etc/openvpn/status.txt
+echo $PORT >> /etc/openvpn/status.txt
 
 #change transmission port on the fly
 


### PR DESCRIPTION
As of Feb 2nd 2017, PIA implemented a new way of requesting an open port and phased out the previous way (that of which was used in these scripts). 

See here for more details on that: https://www.privateinternetaccess.com/forum/discussion/23431/new-pia-port-forwarding-api

With this new implementation a cron job polling for a new port is no longer requrired just once on reboot.

The VPN IP and Port are now exported to a text file once connected.

The Transmission script wasn't tested, however the changes made to it were identical to that of the deluge script which was tested (on a split VPN system). 